### PR TITLE
Upgrade the NuGet version to 31.1.17 in all .NET Framework projects - RichTextBox Examples

### DIFF
--- a/Samples/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion.csproj
+++ b/Samples/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion.csproj
@@ -34,23 +34,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.30.1.37\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.30.1.37\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.31.1.17\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    </Reference>
+    <Reference Include="Syncfusion.Shared.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.31.1.17\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Samples/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion/packages.config
+++ b/Samples/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.DocIO.Wpf" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Shared.WPF" version="30.1.37" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.DocIO.Wpf" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Shared.WPF" version="31.1.17" targetFramework="net472" />
 </packages>

--- a/Samples/Automatic Suggestion/Custom Suggestion Provider/Custom Suggestion Provider/Custom Suggestion Provider.csproj
+++ b/Samples/Automatic Suggestion/Custom Suggestion Provider/Custom Suggestion Provider/Custom Suggestion Provider.csproj
@@ -34,23 +34,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.30.1.37\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.30.1.37\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.31.1.17\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    </Reference>
+    <Reference Include="Syncfusion.Shared.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.31.1.17\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Samples/Automatic Suggestion/Custom Suggestion Provider/Custom Suggestion Provider/packages.config
+++ b/Samples/Automatic Suggestion/Custom Suggestion Provider/Custom Suggestion Provider/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.DocIO.Wpf" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Shared.WPF" version="30.1.37" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.DocIO.Wpf" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Shared.WPF" version="31.1.17" targetFramework="net472" />
 </packages>

--- a/Samples/Automatic Suggestion/Multiple Suggestion Provider/Multiple Suggestion Provider/Multiple Suggestion Provider.csproj
+++ b/Samples/Automatic Suggestion/Multiple Suggestion Provider/Multiple Suggestion Provider/Multiple Suggestion Provider.csproj
@@ -34,23 +34,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-     <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.30.1.37\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.30.1.37\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.31.1.17\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    </Reference>
+    <Reference Include="Syncfusion.Shared.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.31.1.17\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Samples/Automatic Suggestion/Multiple Suggestion Provider/Multiple Suggestion Provider/packages.config
+++ b/Samples/Automatic Suggestion/Multiple Suggestion Provider/Multiple Suggestion Provider/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.DocIO.Wpf" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Shared.WPF" version="30.1.37" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.DocIO.Wpf" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Shared.WPF" version="31.1.17" targetFramework="net472" />
 </packages>

--- a/Samples/Localization/Localization/Localization.csproj
+++ b/Samples/Localization/Localization/Localization.csproj
@@ -35,29 +35,32 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.Wpf.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.Wpf.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfRichTextBoxAdv.WPF.30.1.37\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfRichTextRibbon.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfRichTextRibbon.WPF.30.1.37\lib\net462\Syncfusion.SfRichTextRibbon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfRichTextBoxAdv.WPF.31.1.17\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Shared.WPF.30.1.37\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfRichTextRibbon.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfRichTextRibbon.WPF.31.1.17\lib\net462\Syncfusion.SfRichTextRibbon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Tools.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Tools.WPF.30.1.37\lib\net462\Syncfusion.Tools.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Shared.WPF.31.1.17\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    </Reference>
+    <Reference Include="Syncfusion.Tools.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Tools.WPF.31.1.17\lib\net462\Syncfusion.Tools.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Samples/Localization/Localization/packages.config
+++ b/Samples/Localization/Localization/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.DocIO.Wpf" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.SfRichTextRibbon.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Shared.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Tools.WPF" version="30.1.37" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.DocIO.Wpf" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.SfRichTextRibbon.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Shared.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Tools.WPF" version="31.1.17" targetFramework="net472" />
 </packages>

--- a/Samples/Standard RichTextBox/Standard RichTextBox/Standard_RichTextBox.csproj
+++ b/Samples/Standard RichTextBox/Standard RichTextBox/Standard_RichTextBox.csproj
@@ -35,23 +35,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.30.1.37\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.30.1.37\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfRichTextBoxAdv.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfRichTextBoxAdv.WPF.31.1.17\lib\net462\Syncfusion.SfRichTextBoxAdv.WPF.dll</HintPath>
+    </Reference>
+    <Reference Include="Syncfusion.Shared.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.31.1.17\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Samples/Standard RichTextBox/Standard RichTextBox/packages.config
+++ b/Samples/Standard RichTextBox/Standard RichTextBox/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.DocIO.Wpf" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="30.1.37" targetFramework="net472" />
-  <package id="Syncfusion.Shared.WPF" version="30.1.37" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.DocIO.Wpf" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.SfRichTextBoxAdv.WPF" version="31.1.17" targetFramework="net472" />
+  <package id="Syncfusion.Shared.WPF" version="31.1.17" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Description: ##
Upgraded the NuGet version to 31.1.17 in all .NET Framework projects for RichTextBox Examples repository.